### PR TITLE
Verschiedene Verbesserungen

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -77,6 +77,76 @@ class Plugin
             error_log(print_r(compact('wp_openantrag_debug'),1)); //send message to debug.log when in debug mode
     }
 
+    /**
+     * Performs an API request
+     * @param $url Complete URL for the API request
+     * @return JSON decoded response as object, throws an exception in case of failure
+     * @static
+     */
+    private static function openantrag_request($url) {
+        $response = wp_remote_get($url);
+
+        if (is_wp_error($response)) {
+            throw new \Exception($response->get_error_message());
+        } elseif (wp_remote_retrieve_body($response) == '' || $response['response']['code'] != 200) {
+            throw new \Exception($response['response']['message']);
+        } else {
+            return json_decode(wp_remote_retrieve_body($response));
+        }
+    }
+
+    /**
+     * Get the display name for a parliament (by sending a request to OpenAntrag)
+     * @param $parliament Key of the parliament
+     * @return Display name, or key in case of failure
+     * @static
+     */
+    public static function openantrag_parliament_getdisplayname($parliament) {
+        $url = sprintf('%s/representation/GetByKey/%s', self::API_HOST, $parliament);
+        try {
+            $response = self::openantrag_request($url);
+            return $response->Name2;
+        } catch (\Exception $e) {
+            return $parliament;
+        }
+    }
+
+    /**
+     * Get the possible process steps for a parliament (by sending a request to OpenAntrag)
+     * @param $parliament Key of the parliament
+     * @return Array of objects containing the steps, or empty array in case of failure
+     * @static
+     */
+    public static function openantrag_parliament_getprocesssteps($parliament) {
+        $url = sprintf('%s/representation/GetProcessSteps/%s', self::API_HOST, $parliament);
+        try { 
+            $response = self::openantrag_request($url);
+            return $response;
+        } catch (\Exception $e) {
+            return array();
+        }
+    }
+
+    /**
+     * Get the latest proposals for a parliament (by sending a request to OpenAntrag)
+     * @param $parliament Key of the parliament
+     * @param $count Maximum number of proposals to be returned
+     * @return Array of proposals, throws an exception in case of failure
+     * @static
+     */
+    public static function openantrag_parliament_getproposals($parliament, $count) {
+        $url = sprintf('%s/proposal/%s/GetTop/%d', self::API_HOST, $parliament, $count);
+        $response = self::openantrag_request($url);
+        $proposals = $response;
+        return $proposals;
+    }
+
+    /**
+     * To be called when plugin cannot be activated, shows an error message
+     * @param $message Error message to be shown
+     * @param $deactivate Optional. If true (default) plugin gets deactivated, otherwise plugin stays enabled
+     * @static
+     */
     public static function bail_on_activation( $message, $deactivate = true ) {
         include dirname(__FILE__) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'plugin_bailout.php';
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -1,16 +1,5 @@
 <?php
 /*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
-/*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2

--- a/Widget.php
+++ b/Widget.php
@@ -1,16 +1,5 @@
 <?php
 /*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
-/*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
@@ -25,7 +14,6 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
-
 
 namespace WP_OpenAntrag;
 

--- a/Widget.php
+++ b/Widget.php
@@ -31,12 +31,12 @@ class Widget extends \WP_Widget {
     }
 
     public function form( $instance ) {
-        if ( $instance['id'] ) {
-            $id = $instance['id'];
+        if ( !empty($instance['parliament']) ) {
+            $parliament = $instance['parliament'];
         } else {
-            $id = '';
+            $parliament = '';
         }
-        if ( $instance['count'] ) {
+        if ( !empty($instance['count']) ) {
             $count = $instance['count'];
         } else {
             $count = 5;
@@ -45,12 +45,15 @@ class Widget extends \WP_Widget {
     }
 
     public function update( $new_instance, $old_instance ) {
-        $instance['id'] = strip_tags( $new_instance['id'] );
-        if (empty($instance['id'])) {
-            // TODO throw new \Exception(__('Parlament darf nicht leer sein', 'wp_openantrag'));
+        $instance = array();
+        if (!empty($new_instance['parliament'])) {
+            $instance['parliament'] = strip_tags( $new_instance['parliament'] );
+        } else {
+            $instance['parliament'] = '';
         }
-        $instance['count'] = strip_tags( $new_instance['count']);
-        if (!is_numeric($instance['count'])) {
+        if (!empty($new_instance['count']) && intval($new_instance['count']) > 0) {
+            $instance['count'] = intval($new_instance['count']);
+        } else {
             $instance['count'] = 5;
         }
         return $instance;
@@ -58,32 +61,58 @@ class Widget extends \WP_Widget {
 
     public function widget( $args, $instance ) {
         extract($args);
-        echo $before_widget;
 
-        $url = sprintf('%s/representation/GetByKey/%s', Plugin::API_HOST, $instance['id']);
-        $rep = json_decode(wp_remote_retrieve_body(wp_remote_get($url)));
-        $displayname = $rep->Name2;
-
-        $url = sprintf('%s/proposal/%s/GetTop/%d', Plugin::API_HOST, $instance['id'], $instance['count']);
-        $proposals = json_decode(wp_remote_retrieve_body(wp_remote_get($url)));
-        $displaydata = array();
-        foreach($proposals as $prop) {
-            $data = array();
-            $data['status'] = '';
-            $data['color'] = '';
-            $statusid = $prop->ID_CurrentProposalStep;
-            foreach($prop->ProposalSteps as $step) {
-                if ($step->Id == $statusid) {
-                    $data['status'] = $step->ProcessStep->ShortCaption;
-                    $data['color'] = $step->ProcessStep->Color;
-                    break;
-                }
-            }
-            $data['fullurl'] = $prop->FullUrl;
-            $data['title'] = $prop->Title;
-            $displaydata[] = $data;
+        if (!empty($instance['parliament'])) {
+            $parliament = $instance['parliament'];
+        } else {
+            return;
         }
-        include dirname(__FILE__) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'widget_display.php';
+        if (!empty($instance['count']) && intval($instance['count']) > 0) {
+            $count = intval($instance['count']);
+        } else {
+            $count = 5;
+        }
+
+        $transient_name = 'openantrag_' . md5(serialize($instance));
+
+        if (false === ($widget_output = get_transient($transient_name))) {
+            $displayname = \WP_OpenAntrag\Plugin::openantrag_parliament_getdisplayname($parliament);
+
+            $displayerror = false;
+            $displayerrormessage = '';
+            $proposals = array();
+
+            try {
+                $proposals = \WP_OpenAntrag\Plugin::openantrag_parliament_getproposals($parliament, $count);
+            } catch (\Exception $e) {
+                $displayerror = true;
+                $displayerrormessage = $e->getMessage();
+            }
+
+            foreach($proposals as $prop) {
+                $data = array();
+                $data['status'] = '';
+                $data['color'] = '';
+                $statusid = $prop->ID_CurrentProposalStep;
+                foreach($prop->ProposalSteps as $step) {
+                    if ($step->Id == $statusid) {
+                        $data['status'] = $step->ProcessStep->ShortCaption;
+                        $data['color'] = $step->ProcessStep->Color;
+                        break;
+                    }
+                }
+                $data['fullurl'] = $prop->FullUrl;
+                $data['title'] = $prop->Title;
+                $displaydata[] = $data;
+            }
+
+            ob_start();
+            include dirname(__FILE__) . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'widget_display.php';
+            $widget_output = ob_get_clean();
+
+            set_transient($transient_name, $widget_output, WP_OPENANTRAG__CACHE_TIME);
+        }
+        echo $widget_output;
     }
 }
 

--- a/shortcode.php
+++ b/shortcode.php
@@ -1,16 +1,5 @@
 <?php
 /*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
-/*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
@@ -25,6 +14,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
+
 add_shortcode('wp_openantrag', 'wp_openantrag_display_shortcode');
 
 function wp_openantrag_display_shortcode($atts, $content = null) {

--- a/templates/plugin_bailout.php
+++ b/templates/plugin_bailout.php
@@ -1,15 +1,4 @@
-<!--
-/*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
+<?php
 /*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -25,7 +14,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
--->
+?>
 <!doctype html>
 <html>
 <head>

--- a/templates/shortcode_display.php
+++ b/templates/shortcode_display.php
@@ -16,7 +16,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 ?>
 <h2><?php echo __('Antr&auml;ge'); echo ' '; echo esc_html($displayname); ?></h2>
-<?php foreach($proposals as $prop): ?>
+<?php
+if ($displayerror) {
+    if ($displayerrormessage) {
+        esc_html_e( sprintf( 'Fehler bei der Anfrage an openantrag.de: %s', $displayerrormessage) , 'wp_openantrag');
+    } else {
+        esc_html_e( 'Unbekannter Fehler bei der Anfrage an openantrag.de.' , 'wp_openantrag');
+    }
+} else {
+    if (count($proposals)) {
+ foreach($proposals as $prop): ?>
     <div style="margin-bottom: 2em;">
     <a href="<?php echo $prop->FullUrl; ?>" target="_blank"><?php echo esc_html($prop->Title); ?></a>
     <br/>
@@ -37,5 +46,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         echo $prop->TextHtml;
     endif; ?>
     </div>
-<?php endforeach ?>
-
+<?php endforeach;
+    } else {
+        esc_html_e( 'Keine Antr&auml;ge vorhanden' , 'wp_openantrag');
+    }
+}
+?>

--- a/templates/shortcode_display.php
+++ b/templates/shortcode_display.php
@@ -1,16 +1,5 @@
 <?php
 /*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
-/*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2

--- a/templates/widget_display.php
+++ b/templates/widget_display.php
@@ -1,16 +1,5 @@
 <?php
 /*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
-/*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2

--- a/templates/widget_display.php
+++ b/templates/widget_display.php
@@ -23,6 +23,14 @@ echo __('Antr&auml;ge');
 <?php
 echo esc_html($displayname);
 echo $after_title;
+if ($displayerror) {
+    if ($displayerrormessage) {
+        esc_html_e( sprintf( 'Fehler bei der Anfrage an openantrag.de: %s', $displayerrormessage) , 'wp_openantrag');
+    } else {
+        esc_html_e( 'Unbekannter Fehler bei der Anfrage an openantrag.de.' , 'wp_openantrag');
+    }
+} else {
+    if (count($displaydata)) {
 ?>
 <ul>
 <?php foreach($displaydata as $data): ?>
@@ -34,5 +42,9 @@ echo $after_title;
 <?php endforeach ?>
 </ul>
 <?php
+    } else {
+        esc_html_e( 'Keine Antr&auml;ge vorhanden' , 'wp_openantrag');
+    }
+}
 echo $after_widget;
 ?>

--- a/templates/widget_form.php
+++ b/templates/widget_form.php
@@ -1,15 +1,4 @@
-<!--
-/*
-Plugin Name: WP_OpenAntrag
-Plugin URI: http://github.com
-Description: Display OpenAntrag
-Version: 0.1
-Author: Jochen Sch&auml;fer
-Author URI: http://www.github.com/josch1710
-License: GPLv2
-Text Domain: wp_openantrag
-*/
-
+<?php
 /*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -25,7 +14,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
--->
+?>
 <p>
     <label for="<?php echo $this->get_field_id( 'id' ); ?>"><?php esc_html_e( 'Parlament:' , 'wp_openantrag'); ?></label>
     <input class="widefat" id="<?php echo $this->get_field_id( 'id' ); ?>" name="<?php echo $this->get_field_name( 'id' ); ?>" type="text" value="<?php echo esc_attr( $id ); ?>" />

--- a/templates/widget_form.php
+++ b/templates/widget_form.php
@@ -16,8 +16,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 ?>
 <p>
-    <label for="<?php echo $this->get_field_id( 'id' ); ?>"><?php esc_html_e( 'Parlament:' , 'wp_openantrag'); ?></label>
-    <input class="widefat" id="<?php echo $this->get_field_id( 'id' ); ?>" name="<?php echo $this->get_field_name( 'id' ); ?>" type="text" value="<?php echo esc_attr( $id ); ?>" />
+    <label for="<?php echo $this->get_field_id( 'parliament' ); ?>"><?php esc_html_e( 'Parlament:' , 'wp_openantrag'); ?></label>
+    <input class="widefat" id="<?php echo $this->get_field_id( 'parliament' ); ?>" name="<?php echo $this->get_field_name( 'parliament' ); ?>" type="text" value="<?php echo esc_attr( $parliament ); ?>" />
 </p>
 <p>
     <label for="<?php echo $this->get_field_id( 'count' ); ?>"><?php esc_html_e( 'Anzahl Antr&auml;ge:' , 'wp_openantrag'); ?></label>

--- a/wp_openantrag.php
+++ b/wp_openantrag.php
@@ -38,6 +38,7 @@ define('WP_OPENANTRAG__MINIMUM_WP_VERSION','3.9');
 define('WP_OPENANTRAG__PLUGIN_URL',plugin_dir_url(__FILE__));
 define('WP_OPENANTRAG__PLUGIN_DIR',plugin_dir_path(__FILE__));
 define('WP_OPENANTRAG__DELETE_LIMIT',100000);
+define('WP_OPENANTRAG__CACHE_TIME',30*MINUTE_IN_SECONDS);
 
 register_activation_hook(__FILE__, function() { \WP_OpenAntrag\Plugin::plugin_activation(); });
 register_deactivation_hook(__FILE__, function() { \WP_OpenAntrag\Plugin::plugin_deactivation(); });


### PR DESCRIPTION
Ich habe einmal versucht, die API-Anfragen etwas fehlertoleranter zu machen. Wenn bei der Abfrage des Parlamentsnamens ein Fehler auftritt, wird einfach der Key angezeigt. Tritt ein Fehler bei der Abfrage der Prozessschritte auf, wird auf die Anzeige der Schritte verzichtet. Diese Informationen sind meines Erachtens nicht ganz so wichtig. Können die Anträge nicht abgefragt werden, wird eine Fehlermeldung ausgegeben. 

Außerdem wird die Ausgabe nun zwischengespeichert, um zu verhindern, dass bei jedem Seitenaufruf die Informationen erneut abgefragt werden müssen. Momentan erfolgt die Zwischenspeicherung für einen Zeitraum für 30 Minuten, dann wird die Ausgabe neu erstellt. Möglicherweise ist hier noch etwas Feintuning möglich.

Den Plugin-Header habe ich aus allen Dateien entfernt, abgesehen von der Haupt-Datei. Damit sollte das Plugin nur noch einmal in der Wordpress-Pluginliste auftauchen.
